### PR TITLE
chore: update references after repo rename to recipe-management-service

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,7 +125,7 @@ graph TB
 
 ### Storage Service
 
-**Repository**: [recipe-management-storage-service](https://github.com/theandiman/recipe-management-storage-service)
+**Repository**: [recipe-management-service](https://github.com/theandiman/recipe-management-service)
 
 **Tech Stack**:
 - Java 21
@@ -156,7 +156,7 @@ graph TB
 - Cloud Build for CI/CD
 - Artifact Registry for container storage
 
-**API Documentation**: https://theandiman.github.io/recipe-management-storage-service/
+**API Documentation**: https://theandiman.github.io/recipe-management-service/
 
 ### Shared Library
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This monorepo organization includes the following services:
 
 - **[recipe-management-frontend](https://github.com/theandiman/recipe-management-frontend)** - React/TypeScript web application
 - **[recipe-management-ai-service](https://github.com/theandiman/recipe-management-ai-service)** - AI recipe generation service (Java/Spring Boot)
-- **[recipe-management-storage-service](https://github.com/theandiman/recipe-management-storage-service)** - Recipe storage and retrieval service (Java/Spring Boot)
+- **[recipe-management-service](https://github.com/theandiman/recipe-management-service)** - Recipe management service (Java/Spring Boot)
 - **[recipe-management-infrastructure](https://github.com/theandiman/recipe-management-infrastructure)** - Infrastructure as Code (Terraform/Pulumi)
 - **[recipe-management-shared](https://github.com/theandiman/recipe-management-shared)** - Shared models and types (TypeScript/Java)
 
@@ -107,7 +107,7 @@ The initial reusable backend workflow design is based on the current `recipe-man
 - [Architecture Overview](./ARCHITECTURE.md)
 - [Reusable Backend Workflows](./docs/BACKEND_REUSABLE_WORKFLOWS.md)
 - [API Documentation - AI Service](https://theandiman.github.io/recipe-management-ai-service/)
-- [API Documentation - Storage Service](https://theandiman.github.io/recipe-management-storage-service/)
+- [API Documentation - Recipe Management Service](https://theandiman.github.io/recipe-management-service/)
 
 ## 🔐 Security
 

--- a/docs/BACKEND_REUSABLE_WORKFLOWS.md
+++ b/docs/BACKEND_REUSABLE_WORKFLOWS.md
@@ -95,7 +95,7 @@ with:
   artifact_registry_repository: recipe-storage
   version_strategy: version-script
   run_sonar: true
-  sonar_project_key: theandiman_recipe-management-storage-service
+  sonar_project_key: theandiman_recipe-management-service
 ```
 
 ## Required secrets in consuming repos


### PR DESCRIPTION
The `recipe-management-storage-service` repository was renamed to `recipe-management-service` on GitHub.

## Changes
- **README.md**: update service link text and URL
- **ARCHITECTURE.md**: update repository link and API documentation URL
- **docs/BACKEND_REUSABLE_WORKFLOWS.md**: update SonarCloud project key example