### PR TITLE
feat: support WIF auth in backend Java Cloud Run CD workflow

### DIFF
--- a/.github/workflows/backend-java-cloud-run-cd.yml
+++ b/.github/workflows/backend-java-cloud-run-cd.yml
@@ -57,10 +57,17 @@ on:
         default: true
         type: boolean
     secrets:
-      GCP_SA_KEY:
-        required: true
       GCP_PROJECT_ID:
         required: true
+      GCP_SA_KEY:
+        description: Service account key JSON. Required when not using Workload Identity Federation.
+        required: false
+      GCP_WORKLOAD_IDENTITY_PROVIDER:
+        description: WIF provider resource name. Required when not using GCP_SA_KEY.
+        required: false
+      GCP_DEPLOY_SA:
+        description: Service account email for WIF impersonation. Required when not using GCP_SA_KEY.
+        required: false
 
 jobs:
   docker:
@@ -70,6 +77,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -81,7 +89,16 @@ jobs:
           name: ${{ inputs.build_artifact_name }}
           path: .
 
-      - name: Authenticate to Google Cloud
+      - name: Authenticate to Google Cloud (WIF)
+        if: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' }}
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SA }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Authenticate to Google Cloud (SA Key)
+        if: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER == '' }}
         run: |
           echo "${{ secrets.GCP_SA_KEY }}" > /tmp/sa-key.json
           gcloud auth activate-service-account --key-file=/tmp/sa-key.json
@@ -113,6 +130,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     permissions:
       actions: read
+      id-token: write
     outputs:
       service-url: ${{ steps.deploy.outputs.service-url }}
 
@@ -123,7 +141,16 @@ jobs:
           name: ${{ inputs.build_artifact_name }}
           path: .
 
-      - name: Authenticate to Google Cloud
+      - name: Authenticate to Google Cloud (WIF)
+        if: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' }}
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SA }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Authenticate to Google Cloud (SA Key)
+        if: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER == '' }}
         run: |
           echo "${{ secrets.GCP_SA_KEY }}" > /tmp/sa-key.json
           gcloud auth activate-service-account --key-file=/tmp/sa-key.json


### PR DESCRIPTION
## Summary

Makes the shared backend Java CD workflow support both WIF and SA key auth.

## Changes

- `GCP_SA_KEY` is now optional (was required)
- New optional secrets: `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_DEPLOY_SA` for WIF
- Both `docker` and `deploy` jobs conditionally select auth method:
  - If `GCP_WORKLOAD_IDENTITY_PROVIDER` is set uses `google-github-actions/auth@v2` with WIF
  - Otherwise falls back to SA key (existing behaviour)
- Added `id-token: write` permission to both jobs (required for OIDC token in WIF)
- Added `project_id` to WIF auth step so gcloud project is set automatically

## Motivation

Unblocks the recipe-management-service pipeline migration (PR #133 in recipe-management-storage-service). That service uses WIF but `GCP_SA_KEY` is empty, causing the shared CD workflow to fail at auth.

The AI service is unaffected - it still has a valid `GCP_SA_KEY` and no WIF secrets, so it takes the SA key path as before.
