### PR TITLE
fix: use inputs.use_wif instead of secrets context in step conditions

### DIFF
--- a/.github/workflows/backend-java-cloud-run-cd.yml
+++ b/.github/workflows/backend-java-cloud-run-cd.yml
@@ -56,6 +56,11 @@ on:
         required: false
         default: true
         type: boolean
+      use_wif:
+        description: Use Workload Identity Federation instead of a service account key
+        required: false
+        default: false
+        type: boolean
     secrets:
       GCP_PROJECT_ID:
         required: true
@@ -90,7 +95,7 @@ jobs:
           path: .
 
       - name: Authenticate to Google Cloud (WIF)
-        if: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' }}
+        if: inputs.use_wif
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -98,7 +103,7 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Authenticate to Google Cloud (SA Key)
-        if: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER == '' }}
+        if: ${{ !inputs.use_wif }}
         run: |
           echo "${{ secrets.GCP_SA_KEY }}" > /tmp/sa-key.json
           gcloud auth activate-service-account --key-file=/tmp/sa-key.json
@@ -142,7 +147,7 @@ jobs:
           path: .
 
       - name: Authenticate to Google Cloud (WIF)
-        if: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' }}
+        if: inputs.use_wif
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -150,7 +155,7 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Authenticate to Google Cloud (SA Key)
-        if: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER == '' }}
+        if: ${{ !inputs.use_wif }}
         run: |
           echo "${{ secrets.GCP_SA_KEY }}" > /tmp/sa-key.json
           gcloud auth activate-service-account --key-file=/tmp/sa-key.json


### PR DESCRIPTION
secrets context is unavailable in step `if:` expressions inside reusable workflows. Replaces the four `secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != ''` conditions with a boolean input `use_wif` that callers set explicitly.