### PR TITLE
fix(ci): allow protected-branch version bumps

### DIFF
--- a/.github/workflows/backend-java-cloud-run-cd.yml
+++ b/.github/workflows/backend-java-cloud-run-cd.yml
@@ -81,6 +81,9 @@ on:
       GCP_DEPLOY_SA:
         description: Service account email for WIF impersonation. Required when not using GCP_SA_KEY.
         required: false
+      GIT_PAT:
+        description: Token used to push version bump commits back to `main` from consuming repositories.
+        required: true
 
 jobs:
   docker:
@@ -278,7 +281,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 2
-          token: ${{ github.token }}
+          token: ${{ secrets.GIT_PAT }}
 
       - name: Prepare next development version
         shell: bash
@@ -306,4 +309,4 @@ jobs:
 
           git add pom.xml
           git commit -m "Bump version to $NEXT_VERSION for next development cycle"
-          git push origin main
+          git push origin HEAD:main

--- a/docs/BACKEND_REUSABLE_WORKFLOWS.md
+++ b/docs/BACKEND_REUSABLE_WORKFLOWS.md
@@ -103,5 +103,6 @@ with:
 - `GCP_SA_KEY` — raw service account key JSON (not base64-encoded)
 - `GCP_PROJECT_ID`
 - `SONAR_TOKEN` when `run_sonar: true`
+- `GIT_PAT` — PAT/fine-grained token required by the reusable CD workflow so version bump commits can be pushed back to protected `main`
 
-The workflows use the built-in `GITHUB_TOKEN` for checkout and GitHub Packages access.
+The workflows still use the built-in `GITHUB_TOKEN` for GitHub Packages access, but the reusable CD workflow assumes consuming repositories provide `GIT_PAT` for the version bump checkout/push.


### PR DESCRIPTION
## Summary
- require `GIT_PAT` in the reusable backend CD workflow
- use that PAT for the version-bump checkout/push back to `main`
- document the `GIT_PAT` expectation for consuming repositories

## Why
`recipe-management-service` is failing in the `Prepare Next Development Version` job because the shared workflow pushes straight to `main`, and protected-branch rules can reject the default GitHub token. This keeps the fix simple by assuming the consuming repo already provides `GIT_PAT`.

## Verification
- `git diff --check`
- VS Code workflow validation for `backend-java-cloud-run-cd.yml`