### PR TITLE
feat(workflows): switch reusable Java CI/CD workflows to Git SHA versioning

### DIFF
--- a/.github/workflows/backend-java-ci.yml
+++ b/.github/workflows/backend-java-ci.yml
@@ -9,9 +9,9 @@ on:
         default: '21'
         type: string
       version_strategy:
-        description: Versioning strategy (`version-script` or `short-sha`)
+        description: Versioning strategy (`short-sha` or `version-script`)
         required: false
-        default: version-script
+        default: short-sha
         type: string
       test_command:
         description: Command to run unit/integration tests
@@ -97,30 +97,10 @@ jobs:
         id: version
         shell: bash
         run: |
-          if [[ "${{ inputs.version_strategy }}" == "short-sha" ]]; then
-            VERSION="${GITHUB_SHA::7}"
-          elif [[ -f version.sh ]]; then
+          if [[ "${{ inputs.version_strategy }}" == "version-script" ]] && [[ -f version.sh ]]; then
             chmod +x version.sh
-            if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-              echo "Main branch build detected - deriving next patch version for release without mutating tracked files"
-              CURRENT_VERSION=$(./version.sh current | sed 's/Current version: //')
-              if [[ "$CURRENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
-                MAJOR="${BASH_REMATCH[1]}"
-                MINOR="${BASH_REMATCH[2]}"
-                PATCH="${BASH_REMATCH[3]}"
-                SUFFIX="${BASH_REMATCH[4]}"
-                NEXT_PATCH=$((PATCH + 1))
-                VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}${SUFFIX}"
-              else
-                echo "Warning: CURRENT_VERSION '$CURRENT_VERSION' does not match expected MAJOR.MINOR.PATCH format; using it as-is"
-                VERSION="$CURRENT_VERSION"
-              fi
-            else
-              echo "Feature/PR branch build detected - using current version"
-              VERSION=$(./version.sh current | sed 's/Current version: //')
-            fi
+            VERSION=$(./version.sh current | sed 's/Current version: //')
           else
-            echo "version.sh not found - falling back to short SHA versioning"
             VERSION="${GITHUB_SHA::7}"
           fi
 

--- a/.github/workflows/backend-java-cloud-run-cd.yml
+++ b/.github/workflows/backend-java-cloud-run-cd.yml
@@ -59,8 +59,8 @@ on:
         required: false
         default: true
         type: boolean
-      run_version_bump:
-        description: Whether to prepare the next development version on main
+      run_post_deploy_tests:
+        description: Whether to run the post-deployment smoke tests
         required: false
         default: true
         type: boolean
@@ -82,8 +82,8 @@ on:
         description: Service account email for WIF impersonation. Required when not using GCP_SA_KEY.
         required: false
       GIT_PAT:
-        description: Token used to push version bump commits back to `main` from consuming repositories.
-        required: true
+        description: Token used to push version bump commits back to `main` (deprecated).
+        required: false
 
 jobs:
   docker:
@@ -258,55 +258,3 @@ jobs:
           echo "Running post-deployment tests against $SERVICE_URL"
           chmod +x "${{ inputs.deployment_test_script }}"
           "./${{ inputs.deployment_test_script }}" "$SERVICE_URL"
-
-  version-bump:
-    name: Prepare Next Development Version
-    runs-on: ubuntu-latest
-    needs:
-      - deploy
-      - security-scan
-      - post-deployment-test
-    if: >-
-      github.ref == 'refs/heads/main' &&
-      inputs.run_version_bump &&
-      always() &&
-      needs.deploy.result == 'success' &&
-      (needs.security-scan.result == 'success' || needs.security-scan.result == 'skipped') &&
-      (needs.post-deployment-test.result == 'success' || needs.post-deployment-test.result == 'skipped')
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
-          token: ${{ secrets.GIT_PAT }}
-
-      - name: Prepare next development version
-        shell: bash
-        run: |
-          if [[ ! -f version.sh ]]; then
-            echo "version.sh not found - skipping development version bump"
-            exit 0
-          fi
-
-          if git log -1 --pretty=format:'%an' | grep -q "CI Bot"; then
-            echo "This commit was already a version bump by CI Bot, skipping to prevent infinite loop"
-            exit 0
-          fi
-
-          echo "Preparing next development version..."
-          chmod +x version.sh
-          ./version.sh bump-patch
-          ./version.sh add-snapshot
-
-          NEXT_VERSION=$(./version.sh current | sed 's/Current version: //')
-          echo "Next development version prepared: $NEXT_VERSION"
-
-          git config --global user.email "ci@recipe-management.com"
-          git config --global user.name "CI Bot"
-
-          git add pom.xml
-          git commit -m "Bump version to $NEXT_VERSION for next development cycle"
-          git push origin HEAD:main

--- a/docs/BACKEND_REUSABLE_WORKFLOWS.md
+++ b/docs/BACKEND_REUSABLE_WORKFLOWS.md
@@ -10,13 +10,13 @@ The default behavior and example wiring are based on the current `recipe-managem
   - Builds Java 21 Spring Boot services
   - Configures Maven for GitHub Packages
   - Runs tests, verification, packaging
+  - Uses Git SHA (`short-sha`) for build versioning
   - Optionally runs SonarCloud
   - Uploads build artifacts on `main`
 - `.github/workflows/backend-java-cloud-run-cd.yml`
   - Builds and pushes Docker images to Artifact Registry
-  - Deploys to Cloud Run
+  - Deploys to Cloud Run using Git SHA tag
   - Optionally runs OWASP ZAP and post-deployment smoke tests
-  - Optionally bumps the next development version when `version.sh` is present
 
 ## Expected files in a service repo
 
@@ -25,15 +25,10 @@ The reusable workflows assume the consuming service repository contains:
 - `pom.xml`
 - `Dockerfile`
 - `test-deployment.sh` for post-deployment smoke tests
-- `version.sh` when using `version-script` versioning
-
-If `version.sh` is absent, the CI workflow automatically falls back to short-SHA versioning, regardless of the `version_strategy` input.
-
-Use `version_strategy: short-sha` only when you want to force short-SHA versioning even when a `version.sh` script is present. This mirrors the current `ai-service` behavior on `main`: script-based versioning when `version.sh` exists, with automatic short-SHA fallback otherwise.
 
 ## Example consumer workflow
 
-A backend service can create a thin wrapper workflow like this. This example intentionally matches the current `recipe-management-ai-service` setup on `main`:
+A backend service can create a thin wrapper workflow like this:
 
 ```yaml
 name: CI/CD Pipeline
@@ -46,7 +41,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   packages: read
 
 concurrency:
@@ -55,54 +50,28 @@ concurrency:
 
 jobs:
   ci:
-    uses: theandiman/recipe-management/.github/workflows/backend-java-ci.yml@v1
+    uses: theandiman/recipe-management/.github/workflows/backend-java-ci.yml@main
     with:
-      version_strategy: version-script
       run_sonar: false
     secrets: inherit
 
   cd:
     needs: ci
-    uses: theandiman/recipe-management/.github/workflows/backend-java-cloud-run-cd.yml@v1
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    uses: theandiman/recipe-management/.github/workflows/backend-java-cloud-run-cd.yml@main
     with:
       service_name: recipe-ai-service
       artifact_registry_repository: recipe-ai
       deployment_test_script: test-deployment.sh
       run_security_scan: true
       run_post_deploy_tests: true
-      run_version_bump: true
     secrets: inherit
-```
-
-## Service-specific inputs
-
-### AI service style wiring
-
-```yaml
-with:
-  service_name: recipe-ai-service
-  artifact_registry_repository: recipe-ai
-  version_strategy: version-script
-```
-
-### Storage service style wiring
-
-This is a deliberate extension from the `ai-service` baseline, adding SonarCloud inputs used by storage service:
-
-```yaml
-with:
-  service_name: recipe-storage-service
-  artifact_registry_repository: recipe-storage
-  version_strategy: version-script
-  run_sonar: true
-  sonar_project_key: theandiman_recipe-management-service
 ```
 
 ## Required secrets in consuming repos
 
-- `GCP_SA_KEY` — raw service account key JSON (not base64-encoded)
+- `GCP_SA_KEY` or WIF credentials (`GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_DEPLOY_SA`)
 - `GCP_PROJECT_ID`
 - `SONAR_TOKEN` when `run_sonar: true`
-- `GIT_PAT` — PAT/fine-grained token required by the reusable CD workflow so version bump commits can be pushed back to protected `main`
 
-The workflows still use the built-in `GITHUB_TOKEN` for GitHub Packages access, but the reusable CD workflow assumes consuming repositories provide `GIT_PAT` for the version bump checkout/push.
+The workflows use the built-in `GITHUB_TOKEN` for GitHub Packages access.


### PR DESCRIPTION
Defaults versioning strategy to Git SHA (`short-sha`) across reusable backend Java workflows, removing the version bump job, `version.sh` dependencies, and `GIT_PAT` requirement.